### PR TITLE
Add pseudo-fullscreen mode for OLED displays

### DIFF
--- a/socks5.py
+++ b/socks5.py
@@ -6,6 +6,7 @@ from io import BytesIO
 import logging
 from select import select
 import socket
+import ui
 import struct
 import threading
 from socketserver import ThreadingMixIn, TCPServer, StreamRequestHandler
@@ -396,6 +397,14 @@ function FindProxyForURL(url, host)
     return server
 
 
+# Handler for full screen button to render a full screen window.
+# Use a two-finger "slide down" gesture to close.
+def full_screen_handler(sender):
+    fs_view = ui.View()
+    fs_view.name = "Full screen"
+    fs_view.background_color = 'black'
+    fs_view.present(style='popover', hide_title_bar=True)
+
 def run_wpad_server(server):
     try:
         server.serve_forever()
@@ -416,6 +425,19 @@ if __name__ == '__main__':
     thread.start()
 
     server = ThreadingTCPServer((SOCKS_HOST, SOCKS_PORT), SocksProxy)
+
+    # Create side panel UI component to enter full screen
+    view = ui.View()
+    view.name = "SOCKS"
+    view.background_color = 'black'
+    view.flex = 'WH'
+    # Add simple button to show full screen popover
+    fs_button = ui.Button(title="Enter full screen")
+    fs_button.action = full_screen_handler
+
+    # Render main UI and full screen button
+    view.add_subview(fs_button)
+    view.present(style='panel', hide_title_bar=True)
     try:
         server.serve_forever()
     except KeyboardInterrupt:


### PR DESCRIPTION
This PR addresses issue #8 and adds a popover pane that can essentially 'black out' the display, which for OLED-based iPhones means that the screen doesn't emit any light, and therefore saves battery life.

The way it works is to add a separate pane adjacent to the console window that has a single button to enable full-screen mode. Clicking that button will add a sub-view that opens the popover to black out the screen. By swiping down on the popover, you can close the popover and exit the pseudo-fullscreen mode while keeping the proxy server running. To enter full screen again, simply click the button from the side pane.

There are a couple caveats with this approach, that I'm planning to look into more for the future:

* When the side pane that has the full screen button is open, as stuff is printed out in the console, the focus will shift over to the console. Once you enter full screen mode, this isn't an issue.
  * Changing logging from `DEBUG` to `ERROR` can reduce the rate that it changes focus over. And is probably very slightly better for performance/battery life anyways, if you don't need it to log every connection/request.
* When charging, the battery icon in the top-right will still show. If the phone is horizontal, or if the phone isn't charging, it won't appear.
* The home bar at the bottom still appears. As a workaround, you can enable ["Guided Access"](https://support.apple.com/en-us/HT202612) mode.
    * This hides the home bar but prevents you from exiting the app until you triple-click the power button again to disable it.

I think if I switched to the Scene library instead of the UI one, it might be possible to remove the battery charging icon in portrait mode. The home bar is probably there to stay outside of using guided access mode.

Photos:

The side pane with the "enter full screen" button, adjacent to the console
![photo_2021-12-26_13-17-50](https://user-images.githubusercontent.com/5190697/147416832-107d08f0-a73a-4903-b82f-8d732d97b37b.jpg)

The fullscreen view in portrait mode while charging
![photo_2021-12-26_13-18-02](https://user-images.githubusercontent.com/5190697/147416852-117a9e03-0632-483a-94e1-d5a0acd267b7.jpg)

Tested on iPhone 7 and 13 Pro.