### PR TITLE
Filter out non routable interfaces by their name

### DIFF
--- a/docs/superpowers/plans/2026-03-25-interface-selector-ui.md
+++ b/docs/superpowers/plans/2026-03-25-interface-selector-ui.md
@@ -1,0 +1,900 @@
+# Network Interface Selector UI — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the auto-select + console UI with a Pythonista `ui` module GUI that lets users pick proxy-access and internet-connection interfaces at runtime, with live traffic stats.
+
+**Architecture:** Extract interface discovery into `lib/interfaces.py`. Add `stop()` to `AsyncProxyServer`. Build a Pythonista `ui.View` in `lib/ui_view.py` that drives server lifecycle from the main thread while asyncio runs in a background thread. Keep the existing console fallback for non-Pythonista environments.
+
+**Tech Stack:** Python 3, Pythonista `ui`/`dialogs`/`console` modules, asyncio, threading
+
+**Spec:** `docs/superpowers/specs/2026-03-25-interface-selector-ui-design.md`
+
+---
+
+### Task 1: Extract interface discovery into `lib/interfaces.py`
+
+Move the interface enumeration/classification logic out of `socks5.py` into a reusable module.
+
+**Files:**
+- Create: `lib/interfaces.py`
+- Modify: `socks5.py:93-245` (remove inline interface logic, import from new module)
+
+- [ ] **Step 1: Create `lib/interfaces.py` with `get_labeled_interfaces()`**
+
+```python
+import socket
+from lib import ifaddrs
+
+
+def _interface_type_label(name):
+    if name.startswith("bridge"):
+        return "Hotspot"
+    if name.startswith("en"):
+        return "WiFi"
+    if name.startswith("utun"):
+        return "VPN"
+    if name.startswith("pdp_ip"):
+        return "Cellular"
+    return "Other"
+
+
+def get_labeled_interfaces():
+    """Return list of (display_string, iface) for all routable, non-loopback IPv4 interfaces."""
+    non_routable_prefixes = ["ipsec", "awdl", "llw", "nan", "rd"]
+    result = []
+    for iface in ifaddrs.get_interfaces():
+        if not iface.addr:
+            continue
+        if iface.addr.family != socket.AF_INET:
+            continue
+        if iface.name.startswith("lo"):
+            continue
+        if any(iface.name.startswith(p) for p in non_routable_prefixes):
+            continue
+        label = _interface_type_label(iface.name)
+        display = f"{iface.name} - {label} ({iface.addr.address})"
+        result.append((display, iface))
+    return result
+
+
+def get_default_selections(labeled):
+    """Apply heuristic: bridge > en for proxy, cell/vpn for connect. Returns (proxy_idx, connect_idx)."""
+    proxy_idx = None
+    connect_idx = None
+    # Proxy: prefer bridge (hotspot), then en (WiFi)
+    for i, (display, iface) in enumerate(labeled):
+        if iface.name.startswith("bridge"):
+            proxy_idx = i
+            break
+    if proxy_idx is None:
+        for i, (display, iface) in enumerate(labeled):
+            if iface.name.startswith("en"):
+                proxy_idx = i
+                break
+    # Connect: prefer utun (VPN), then pdp_ip (cellular), then any non-proxy interface
+    for i, (display, iface) in enumerate(labeled):
+        if iface.name.startswith("utun"):
+            connect_idx = i
+            break
+    if connect_idx is None:
+        for i, (display, iface) in enumerate(labeled):
+            if iface.name.startswith("pdp_ip"):
+                connect_idx = i
+                break
+    if connect_idx is None:
+        for i, (display, iface) in enumerate(labeled):
+            if not iface.name.startswith("bridge") and not iface.name.startswith("en"):
+                connect_idx = i
+                break
+    return proxy_idx, connect_idx
+```
+
+- [ ] **Step 2: Verify module loads**
+
+Run: `python -c "from lib.interfaces import get_labeled_interfaces, get_default_selections; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/interfaces.py
+git commit -m "feat: extract interface discovery into lib/interfaces.py"
+```
+
+---
+
+### Task 2: Add `stop()` to `AsyncProxyServer`
+
+Store the `asyncio.Server` handle and expose a `stop()` coroutine so the UI can shut down and restart servers.
+
+**Files:**
+- Modify: `lib/proxy_server.py:138-145`
+
+- [ ] **Step 1: Store server handle and add `stop()`**
+
+Replace the `run()` method in `AsyncProxyServer` (lines 138-145):
+
+```python
+    async def run(self) -> None:
+        self._server = await asyncio.start_server(
+            self.client_connected,
+            host=self.listen_hosts,
+            port=self.listen_port,
+            reuse_address=True,
+        )
+        await self._server.serve_forever()
+
+    async def stop(self) -> None:
+        if hasattr(self, '_server') and self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+```
+
+- [ ] **Step 2: Verify no import errors**
+
+Run: `python -c "from lib.proxy_server import AsyncProxyServer; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/proxy_server.py
+git commit -m "feat: add stop() method to AsyncProxyServer for runtime restart"
+```
+
+---
+
+### Task 3: Add `get_snapshot()` to `StatusMonitor` for thread-safe stats reading
+
+The UI thread needs to read stats without races. Add a snapshot method that returns a frozen dict.
+
+**Files:**
+- Modify: `lib/status.py:72-107`
+
+- [ ] **Step 1: Add thread-safe `get_snapshot()` and a `threading.Lock` to `StatusMonitor`**
+
+First, add `import threading` at the top of `lib/status.py`.
+
+Then add `self._lock = threading.Lock()` in `StatusMonitor.__init__` after `self.num_errors = 0`.
+
+Wrap the mutating methods `add_inbound`, `add_outbound`, `add_connection`, `remove_connection` with `with self._lock:`.
+
+Add after the `emit()` method (after line 106):
+
+```python
+    def get_snapshot(self) -> dict:
+        """Return a frozen snapshot of current stats for the UI to read.
+        Thread-safe: uses a lock to prevent torn reads from ThroughputTracker."""
+        with self._lock:
+            inbound_average, inbound_total = self.inbound.update()
+            outbound_average, outbound_total = self.outbound.update()
+            return {
+                "inbound_speed": inbound_average,
+                "inbound_total": inbound_total,
+                "outbound_speed": outbound_average,
+                "outbound_total": outbound_total,
+                "connections": self.num_connections,
+                "errors": self.num_errors,
+                "messages": list(self.messages),
+            }
+```
+
+- [ ] **Step 2: Verify no import errors**
+
+Run: `python -c "from lib.status import StatusMonitor; s = StatusMonitor(''); print(s.get_snapshot())"`
+Expected: dict with all keys present
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/status.py
+git commit -m "feat: add get_snapshot() to StatusMonitor for thread-safe UI reads"
+```
+
+---
+
+### Task 4: Create the Pythonista UI view (`lib/ui_view.py`)
+
+Build the main `ui.View` subclass with interface selection, stats display, and server control.
+
+**Files:**
+- Create: `lib/ui_view.py`
+
+- [ ] **Step 1: Create `lib/ui_view.py`**
+
+```python
+import sys
+import threading
+import asyncio
+import dialogs
+
+from lib.interfaces import get_labeled_interfaces, get_default_selections
+from lib.status import StatusMonitor
+
+IS_PYTHONISTA = "Pythonista" in sys.executable
+
+if IS_PYTHONISTA:
+    import ui
+    import console
+    from objc_util import on_main_thread
+
+
+def _make_label(text, frame, font_size=14, alignment=ui.ALIGN_LEFT if IS_PYTHONISTA else 0):
+    lbl = ui.Label()
+    lbl.text = text
+    lbl.frame = frame
+    lbl.font = ("<system>", font_size)
+    lbl.alignment = alignment
+    lbl.number_of_lines = 0
+    return lbl
+
+
+def _make_button(title, frame, action):
+    btn = ui.Button(type="system")
+    btn.title = title
+    btn.frame = frame
+    btn.action = action
+    return btn
+
+
+class ProxyUIView(ui.View):
+    def __init__(self, stats, start_server_cb, stop_server_cb, socks_port=9876, http_port=9877, wpad_port=8088):
+        super().__init__()
+        self.name = "SOCKS5 Proxy"
+        self.background_color = "white"
+        self.stats = stats
+        self._start_server_cb = start_server_cb
+        self._stop_server_cb = stop_server_cb
+        self._socks_port = socks_port
+        self._http_port = http_port
+        self._wpad_port = wpad_port
+        self._running = False
+
+        # Current selections
+        self._proxy_iface = None
+        self._connect_iface = None
+
+        # Detect interfaces and pick defaults
+        self._refresh_and_set_defaults()
+
+        # Keep screen on
+        on_main_thread(console.set_idle_timer_disabled)(True)
+
+        self._build_ui()
+        self.update_interval = 1.0
+
+    def _refresh_and_set_defaults(self):
+        labeled = get_labeled_interfaces()
+        proxy_idx, connect_idx = get_default_selections(labeled)
+        if labeled:
+            if proxy_idx is not None:
+                self._proxy_iface = labeled[proxy_idx]
+            else:
+                self._proxy_iface = labeled[0]
+            if connect_idx is not None:
+                self._connect_iface = labeled[connect_idx]
+            elif len(labeled) > 1:
+                self._connect_iface = labeled[1]
+            else:
+                self._connect_iface = labeled[0]
+
+    def _build_ui(self):
+        w = self.width
+        y = 10
+        pad = 10
+
+        # --- Proxy access row ---
+        self._proxy_label = _make_label("", (pad, y, w - 100, 36))
+        self._update_proxy_label()
+        self.add_subview(self._proxy_label)
+
+        self._proxy_btn = _make_button("변경", (w - 80, y, 70, 36), self._change_proxy)
+        self.add_subview(self._proxy_btn)
+        y += 44
+
+        # --- Connect row ---
+        self._connect_label = _make_label("", (pad, y, w - 100, 36))
+        self._update_connect_label()
+        self.add_subview(self._connect_label)
+
+        self._connect_btn = _make_button("변경", (w - 80, y, 70, 36), self._change_connect)
+        self.add_subview(self._connect_btn)
+        y += 52
+
+        # --- Separator ---
+        sep = ui.View(frame=(pad, y, w - 2 * pad, 1))
+        sep.background_color = "#cccccc"
+        self.add_subview(sep)
+        y += 10
+
+        # --- Status label ---
+        self._status_label = _make_label("Status: Stopped", (pad, y, w - 2 * pad, 24), font_size=16)
+        self.add_subview(self._status_label)
+        y += 30
+
+        # --- Stats area ---
+        self._stats_text = ui.TextView()
+        self._stats_text.frame = (pad, y, w - 2 * pad, 200)
+        self._stats_text.editable = False
+        self._stats_text.font = ("<system>", 13)
+        self.add_subview(self._stats_text)
+        y += 210
+
+        # --- Log area ---
+        self._log_label = _make_label("", (pad, y, w - 2 * pad, 100), font_size=11)
+        self.add_subview(self._log_label)
+        y += 110
+
+        # --- Start/Restart button ---
+        self._action_btn = _make_button("Start", (pad, y, w - 2 * pad, 44), self._toggle_server)
+        self._action_btn.background_color = "#007AFF"
+        self._action_btn.tint_color = "white"
+        self._action_btn.corner_radius = 8
+        self.add_subview(self._action_btn)
+
+    def _update_proxy_label(self):
+        display = self._proxy_iface[0] if self._proxy_iface else "None"
+        self._proxy_label.text = f"Proxy: {display}"
+
+    def _update_connect_label(self):
+        display = self._connect_iface[0] if self._connect_iface else "None"
+        self._connect_label.text = f"Connect: {display}"
+
+    def _change_proxy(self, sender):
+        labeled = get_labeled_interfaces()
+        items = [d for d, _ in labeled]
+        choice = dialogs.list_dialog("Proxy 접근 인터페이스", items)
+        if choice is not None:
+            idx = items.index(choice)
+            self._proxy_iface = labeled[idx]
+            self._update_proxy_label()
+            if self._running:
+                self._restart_server()
+
+    def _change_connect(self, sender):
+        labeled = get_labeled_interfaces()
+        items = [d for d, _ in labeled]
+        choice = dialogs.list_dialog("인터넷 연결 인터페이스", items)
+        if choice is not None:
+            idx = items.index(choice)
+            self._connect_iface = labeled[idx]
+            self._update_connect_label()
+            if self._running:
+                self._restart_server()
+
+    def _toggle_server(self, sender):
+        if self._running:
+            self._stop_server_cb()
+            self._running = False
+            self._status_label.text = "Status: Stopped"
+            self._action_btn.title = "Start"
+        else:
+            if self._proxy_iface is None or self._connect_iface is None:
+                dialogs.alert("Error", "Select both interfaces first.")
+                return
+            proxy_addr = self._proxy_iface[1].addr.address
+            connect_addr = self._connect_iface[1].addr.address
+            connect_name = self._connect_iface[1].name
+            self._start_server_cb(proxy_addr, connect_addr, connect_name)
+            self._running = True
+            self._status_label.text = "Status: Running"
+            self._action_btn.title = "Stop"
+
+    def _restart_server(self):
+        self._stop_server_cb()
+        proxy_addr = self._proxy_iface[1].addr.address
+        connect_addr = self._connect_iface[1].addr.address
+        connect_name = self._connect_iface[1].name
+        self._start_server_cb(proxy_addr, connect_addr, connect_name)
+        self._status_label.text = "Status: Running (restarted)"
+
+    def update(self):
+        """Called by Pythonista UI at update_interval frequency."""
+        if not self._running:
+            return
+        snap = self.stats.get_snapshot()
+        megabit = 1024 * 1024 / 8
+        megabyte = 1024 * 1024
+
+        proxy_addr = self._proxy_iface[1].addr.address if self._proxy_iface else "?"
+        lines = [
+            f"In:    {snap['inbound_speed'] / megabit:.2f} Mbps",
+            f"Out:   {snap['outbound_speed'] / megabit:.2f} Mbps",
+            f"",
+            f"Connections: {snap['connections']}",
+            f"Total In:    {snap['inbound_total'] / megabyte:.2f} MB",
+            f"Total Out:   {snap['outbound_total'] / megabyte:.2f} MB",
+            f"Total:       {(snap['inbound_total'] + snap['outbound_total']) / megabyte:.2f} MB",
+            f"",
+            f"PAC URL: http://{proxy_addr}:{self._wpad_port}/wpad.dat",
+            f"SOCKS:   {proxy_addr}:{self._socks_port}",
+            f"HTTP:    {proxy_addr}:{self._http_port}",
+        ]
+        self._stats_text.text = "\n".join(lines)
+
+        if snap["messages"]:
+            self._log_label.text = "Log:\n" + "\n".join(snap["messages"][-5:])
+        if snap["errors"]:
+            self._log_label.text += f"\nErrors: {snap['errors']}"
+
+    @property
+    def proxy_address(self):
+        return self._proxy_iface[1].addr.address if self._proxy_iface else None
+
+    @property
+    def connect_address(self):
+        return self._connect_iface[1].addr.address if self._connect_iface else None
+
+    @property
+    def connect_iface_name(self):
+        return self._connect_iface[1].name if self._connect_iface else None
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add lib/ui_view.py
+git commit -m "feat: add Pythonista UI view for interface selection and stats"
+```
+
+---
+
+### Task 5: Rewrite `socks5.py` main to use UI + server lifecycle
+
+Rework the main entry point to: show the UI on Pythonista, run asyncio in a background thread, support stop/restart. Keep console fallback for non-Pythonista.
+
+**Files:**
+- Modify: `socks5.py` (major rewrite of lines 93-344)
+
+- [ ] **Step 1: Rewrite `socks5.py`**
+
+The full rewritten file:
+
+```python
+#!python3
+# Socks5/HTTP Proxy server for Pythonista by @nneonneo
+# Pretty statistics view and IPv6 support added by @philrosenthal
+
+import asyncio
+import ipaddress
+import logging
+import socket
+import sys
+import threading
+
+from lib.socks5_server import AsyncSocks5Handler
+from lib.http_proxy_server import AsyncHTTPProxyHandler
+from lib.proxy_server import AsyncProxyServer
+from lib.status import StatusMonitor
+
+logging.basicConfig(level=logging.ERROR)
+
+LISTEN_HOST = "0.0.0.0"
+SOCKS_PORT = 9876
+HTTP_PORT = 9877
+WPAD_PORT = 8088
+
+USE_PHONE_VPN = True
+CUSTOM_RESOLVERS = []
+
+IS_PYTHONISTA = "Pythonista" in sys.executable
+
+
+def is_globally_routable(ipv6_address):
+    non_routable_networks = [
+        "ff00::/8",
+        "fe80::/10",
+        "fc00::/7",
+        "::/8",
+        "2001:db8::/32",
+        "2001::/32",
+        "2002::/16",
+        "ff02::/16",
+    ]
+    for network in non_routable_networks:
+        if ipaddress.ip_address(ipv6_address) in ipaddress.ip_network(network):
+            return False
+    return True
+
+
+def is_routable_interface(interface_name):
+    non_routable_interface_prefixes = [
+        "ipsec",
+        "awdl",
+        "llw",
+        "nan",
+        "rd",
+    ]
+    return not any(
+        interface_name.startswith(prefix) for prefix in non_routable_interface_prefixes
+    )
+
+
+DEFAULT_RESOLVERS = [
+    "1.0.0.1",
+    "1.1.1.1",
+    "8.8.8.8",
+    "2606:4700:4700::1111",
+    "2606:4700:4700::1001",
+    "2001:4860:4860::8844",
+]
+
+try:
+    import dns.asyncresolver
+
+    resolver = dns.asyncresolver.Resolver(configure=False)
+    resolver.nameservers += CUSTOM_RESOLVERS or DEFAULT_RESOLVERS
+except ImportError:
+    print("Warning: dnspython not available; falling back to system DNS")
+    resolver = None
+
+
+def resolve_ipv6_for_interface(iface_name, is_vpn=False):
+    """Find the best IPv6 address matching a given interface name."""
+    from lib import ifaddrs
+
+    all_ifaces = ifaddrs.get_interfaces()
+    # First try: match by interface name
+    ipv6_list = [
+        iface
+        for iface in all_ifaces
+        if iface.addr
+        and iface.addr.family == socket.AF_INET6
+        and iface.addr.address
+        and iface.name == iface_name
+        and is_routable_interface(iface.name)
+        and (is_globally_routable(iface.addr.address) if not is_vpn else True)
+    ]
+    if ipv6_list:
+        return ipv6_list[-1].addr.address
+
+    # Fallback: any routable IPv6
+    if not is_vpn:
+        ipv6_list = [
+            iface
+            for iface in all_ifaces
+            if iface.addr
+            and iface.addr.family == socket.AF_INET6
+            and iface.addr.address
+            and is_globally_routable(iface.addr.address)
+            and is_routable_interface(iface.name)
+        ]
+        if ipv6_list:
+            return ipv6_list[-1].addr.address
+    return None
+
+
+def test_ipv6_connectivity(ipv6_address):
+    """Test if an IPv6 address can reach the internet. Returns the address or None."""
+    try:
+        test_socket = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        test_socket.settimeout(5)
+        test_socket.bind((ipv6_address, 0))
+        test_socket.connect(("2606:4700:4700::1111", 80))
+        test_socket.close()
+        return ipv6_address
+    except Exception:
+        try:
+            test_socket.close()
+        except Exception:
+            pass
+        return None
+
+
+def create_wpad_server(hhost, hport, phost, pport):
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    class HTTPHandler(BaseHTTPRequestHandler):
+        def do_HEAD(s):
+            s.send_response(200)
+            s.send_header("Content-type", "application/x-ns-proxy-autoconfig")
+            s.end_headers()
+
+        def do_GET(s):
+            s.send_response(200)
+            s.send_header("Content-type", "application/x-ns-proxy-autoconfig")
+            s.end_headers()
+            s.wfile.write(
+                (
+                    """
+function FindProxyForURL(url, host)
+{
+   if (isInNet(host, "192.168.0.0", "255.255.0.0")) {
+      return "DIRECT";
+   } else if (isInNet(host, "172.16.0.0", "255.240.0.0")) {
+      return "DIRECT";
+   } else if (isInNet(host, "10.0.0.0", "255.0.0.0")) {
+      return "DIRECT";
+   } else {
+      return "SOCKS5 %s:%d; SOCKS %s:%d";
+   }
+}
+"""
+                    % (phost, pport, phost, pport)
+                )
+                .lstrip()
+                .encode()
+            )
+
+    HTTPServer.allow_reuse_address = True
+    server = HTTPServer((hhost, hport), HTTPHandler)
+    return server
+
+
+# --- Server lifecycle management ---
+
+class ServerManager:
+    """Manages SOCKS, HTTP, and WPAD server lifecycle."""
+
+    def __init__(self, stats):
+        self.stats = stats
+        self._loop = None
+        self._thread = None
+        self._socks_server = None
+        self._http_server = None
+        self._wpad_server = None
+        self._wpad_thread = None
+        self._socks_task = None
+        self._http_task = None
+
+    def start(self, proxy_host, connect_host_ipv4, connect_iface_name):
+        is_vpn = connect_iface_name.startswith("utun")
+        ipv6_addr = resolve_ipv6_for_interface(connect_iface_name, is_vpn=is_vpn)
+        connect_host_ipv6 = test_ipv6_connectivity(ipv6_addr) if ipv6_addr else None
+
+        # WPAD server
+        self._wpad_server = create_wpad_server(LISTEN_HOST, WPAD_PORT, proxy_host, SOCKS_PORT)
+        self._wpad_thread = threading.Thread(target=self._run_wpad, daemon=True)
+        self._wpad_thread.start()
+
+        # asyncio event loop in background thread
+        self._loop = asyncio.new_event_loop()
+
+        self._socks_server = AsyncProxyServer(
+            AsyncSocks5Handler,
+            listen_hosts=LISTEN_HOST,
+            listen_port=SOCKS_PORT,
+            traffic_stats=self.stats,
+            resolver=resolver,
+            connect_host_ipv4=connect_host_ipv4,
+            connect_host_ipv6=connect_host_ipv6,
+        )
+        self._http_server = AsyncProxyServer(
+            AsyncHTTPProxyHandler,
+            listen_hosts=LISTEN_HOST,
+            listen_port=HTTP_PORT,
+            traffic_stats=self.stats,
+            resolver=resolver,
+            connect_host_ipv4=connect_host_ipv4,
+            connect_host_ipv6=connect_host_ipv6,
+        )
+
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+
+    def _run_loop(self):
+        asyncio.set_event_loop(self._loop)
+
+        async def _serve():
+            self._socks_task = asyncio.create_task(self._socks_server.run())
+            self._http_task = asyncio.create_task(self._http_server.run())
+            # Keep the loop alive until tasks are cancelled
+            await asyncio.gather(self._socks_task, self._http_task, return_exceptions=True)
+
+        self._serve_task = self._loop.create_task(_serve())
+        self._loop.run_forever()
+
+    def _run_wpad(self):
+        try:
+            self._wpad_server.serve_forever()
+        except Exception:
+            pass
+
+    def stop(self):
+        if self._loop and self._loop.is_running():
+            async def _stop_all():
+                # Stop servers gracefully
+                if self._socks_server:
+                    await self._socks_server.stop()
+                if self._http_server:
+                    await self._http_server.stop()
+                # Cancel the tasks to avoid zombie coroutines
+                for task in [self._socks_task, self._http_task]:
+                    if task and not task.done():
+                        task.cancel()
+
+            future = asyncio.run_coroutine_threadsafe(_stop_all(), self._loop)
+            future.result(timeout=5)
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._thread.join(timeout=5)
+
+        if self._wpad_server:
+            self._wpad_server.shutdown()
+            self._wpad_server = None
+
+        self._socks_server = None
+        self._http_server = None
+        self._loop = None
+        self._thread = None
+
+
+# --- Entry points ---
+
+def run_with_ui():
+    """Pythonista GUI mode."""
+    from lib.ui_view import ProxyUIView
+
+    stats = StatusMonitor("")
+    logging.getLogger().addHandler(stats)
+    manager = ServerManager(stats)
+
+    def start_server(proxy_addr, connect_addr, connect_name):
+        manager.start(proxy_addr, connect_addr, connect_name)
+
+    def stop_server():
+        manager.stop()
+
+    view = ProxyUIView(stats, start_server, stop_server, socks_port=SOCKS_PORT, http_port=HTTP_PORT, wpad_port=WPAD_PORT)
+    view.present("fullscreen")
+
+
+def run_console():
+    """Original console mode for non-Pythonista environments."""
+    from collections import defaultdict
+    from lib import ifaddrs
+
+    PROXY_HOST = "172.20.10.1"
+    CONNECT_HOST_IPV4 = "0.0.0.0"
+    CONNECT_HOST_IPV6 = None
+    initial_output = ""
+
+    try:
+        interfaces = ifaddrs.get_interfaces()
+        iftypes = defaultdict(list)
+
+        for iface in interfaces:
+            if not iface.addr:
+                continue
+            if iface.name.startswith("lo"):
+                continue
+            if iface.name.startswith("en"):
+                iftypes["en"].append(iface)
+            elif iface.name.startswith("bridge"):
+                iftypes["bridge"].append(iface)
+            elif iface.name.startswith("utun"):
+                iftypes["vpn"].append(iface)
+            else:
+                iftypes["cell"].append(iface)
+
+        if iftypes["vpn"] and USE_PHONE_VPN:
+            initial_output += "VPN use enabled (change with USE_PHONE_VPN)\n"
+            new_ifaces = list(iftypes["vpn"]) + list(iftypes["cell"])
+            iftypes["cell"] = new_ifaces
+
+        if iftypes["bridge"]:
+            iface = next(
+                (i for i in iftypes["bridge"] if i.addr.family == socket.AF_INET), None
+            )
+            if iface:
+                initial_output += "Assuming proxy will be accessed over hotspot (%s) at %s\n" % (iface.name, iface.addr.address)
+                PROXY_HOST = iface.addr.address
+        elif iftypes["en"]:
+            iface = next(
+                (i for i in iftypes["en"] if i.addr.family == socket.AF_INET), None
+            )
+            if iface:
+                initial_output += "Assuming proxy will be accessed over WiFi (%s) at %s\n" % (iface.name, iface.addr.address)
+                PROXY_HOST = iface.addr.address
+        else:
+            initial_output += "Warning: could not get WiFi address; assuming %s\n" % PROXY_HOST
+
+        if iftypes["cell"]:
+            iface_ipv4 = next(
+                (i for i in iftypes["cell"] if i.addr.family == socket.AF_INET and is_routable_interface(i.name)),
+                None,
+            )
+            if iface_ipv4:
+                initial_output += "Will connect to IPv4 servers over interface %s at %s\n" % (iface_ipv4.name, iface_ipv4.addr.address)
+                CONNECT_HOST_IPV4 = iface_ipv4.addr.address
+                is_vpn = iface_ipv4.name.startswith("utun")
+                ipv6_addr = resolve_ipv6_for_interface(iface_ipv4.name, is_vpn=is_vpn)
+                if ipv6_addr:
+                    CONNECT_HOST_IPV6 = test_ipv6_connectivity(ipv6_addr)
+                    if CONNECT_HOST_IPV6:
+                        initial_output += "Will connect to IPv6 servers at %s\n" % CONNECT_HOST_IPV6
+    except Exception as e:
+        logging.error("Address detection failed: %s: %s", type(e).__name__, e)
+        import traceback
+        traceback.print_exc()
+
+    wpad_server = create_wpad_server(LISTEN_HOST, WPAD_PORT, PROXY_HOST, SOCKS_PORT)
+
+    initial_output += "PAC URL: http://{}:{}/wpad.dat\n".format(PROXY_HOST, WPAD_PORT)
+    initial_output += "SOCKS Address: {}:{}\n".format(PROXY_HOST or LISTEN_HOST, SOCKS_PORT)
+    initial_output += "HTTP Proxy Address: {}:{}\n".format(PROXY_HOST or LISTEN_HOST, HTTP_PORT)
+    stats = StatusMonitor(initial_output)
+    logging.getLogger().addHandler(stats)
+
+    thread = threading.Thread(target=lambda: wpad_server.serve_forever(), daemon=True)
+    thread.start()
+
+    async def main():
+        socks = AsyncProxyServer(
+            AsyncSocks5Handler,
+            listen_hosts=LISTEN_HOST,
+            listen_port=SOCKS_PORT,
+            traffic_stats=stats,
+            resolver=resolver,
+            connect_host_ipv4=CONNECT_HOST_IPV4,
+            connect_host_ipv6=CONNECT_HOST_IPV6,
+        )
+        asyncio.create_task(socks.run())
+
+        http = AsyncProxyServer(
+            AsyncHTTPProxyHandler,
+            listen_hosts=LISTEN_HOST,
+            listen_port=HTTP_PORT,
+            traffic_stats=stats,
+            resolver=resolver,
+            connect_host_ipv4=CONNECT_HOST_IPV4,
+            connect_host_ipv6=CONNECT_HOST_IPV6,
+        )
+        asyncio.create_task(http.run())
+
+        await stats.render_forever()
+
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("Shutting down.")
+        wpad_server.shutdown()
+
+
+if __name__ == "__main__":
+    if IS_PYTHONISTA:
+        run_with_ui()
+    else:
+        run_console()
+```
+
+- [ ] **Step 2: Verify syntax**
+
+Run: `python -c "import py_compile; py_compile.compile('socks5.py', doraise=True); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add socks5.py
+git commit -m "feat: add GUI mode with ServerManager, keep console fallback"
+```
+
+---
+
+### Task 6: End-to-end verification
+
+Verify the whole thing loads and the non-Pythonista console path still works.
+
+**Files:** (none modified)
+
+- [ ] **Step 1: Verify all imports resolve**
+
+Run: `python -c "from lib.interfaces import get_labeled_interfaces; from lib.ui_view import ProxyUIView; from lib.proxy_server import AsyncProxyServer; print('All imports OK')"`
+
+Note: This will fail if Pythonista `ui` module is not available. On non-Pythonista, verify:
+Run: `python -c "from lib.interfaces import get_labeled_interfaces; from lib.proxy_server import AsyncProxyServer; print('Core imports OK')"`
+Expected: `Core imports OK`
+
+- [ ] **Step 2: Verify console mode starts without errors**
+
+Run: `timeout 3 python socks5.py || true`
+Expected: Server starts and shows interface detection output (or times out after 3s which is fine)
+
+- [ ] **Step 3: Final commit if any adjustments needed**
+
+```bash
+git add -A
+git commit -m "fix: adjustments from end-to-end verification"
+```

--- a/docs/superpowers/specs/2026-03-25-interface-selector-ui-design.md
+++ b/docs/superpowers/specs/2026-03-25-interface-selector-ui-design.md
@@ -1,0 +1,97 @@
+# Network Interface Selector UI
+
+## Problem
+
+The proxy server automatically selects the first matching network interface for both proxy access (PROXY_HOST) and internet connection (CONNECT_HOST). Users cannot choose which interfaces to use, making it impossible to route traffic through specific networks like Tailscale VPN at runtime.
+
+## Solution
+
+Replace the console-based status display with a Pythonista `ui` module GUI that combines interface selection with live traffic monitoring. Users can change interfaces while the server is running.
+
+## UI Layout
+
+```
+┌─────────────────────────────────┐
+│  Proxy 접근: en0 - WiFi (...)   │  [변경]
+│  인터넷 연결: pdp_ip0 - Cell .. │  [변경]
+├─────────────────────────────────┤
+│  Status: Running                │
+│  In:  12.34 Mbps                │
+│  Out:  5.67 Mbps                │
+│  Connections: 3                 │
+│  Total In:  123.45 MB           │
+│  Total Out:  67.89 MB           │
+│  PAC URL: http://...            │
+│  SOCKS: ...:9876                │
+│  HTTP:  ...:9877                │
+├─────────────────────────────────┤
+│  Last 5 log messages:           │
+│    ...                          │
+├─────────────────────────────────┤
+│        [Start / Restart]        │
+└─────────────────────────────────┘
+```
+
+## Interface List Display Format
+
+Each interface shown as: `{name} - {type_label} ({ip_address})`
+
+Type labels derived from interface name prefix:
+- `en*` → WiFi
+- `bridge*` → Hotspot
+- `utun*` → VPN
+- `pdp_ip*` → Cellular
+- others → Other
+
+Only IPv4 interfaces shown in the selection dialogs. IPv6 is auto-matched from the same interface name as the selected IPv4 CONNECT_HOST interface (existing behavior preserved).
+
+## Components
+
+### 1. Interface discovery (modify existing logic in `socks5.py`)
+
+Extract the interface enumeration and classification into a reusable function that returns a list of available interfaces with their type labels. This replaces the current inline classification code.
+
+```python
+def get_labeled_interfaces():
+    """Return list of (display_string, iface) tuples for all routable IPv4 interfaces."""
+```
+
+### 2. UI view (`lib/ui_view.py` — new file)
+
+A Pythonista `ui.View` subclass that:
+- Shows two labeled rows for current proxy access and connect interfaces, each with a "변경" (Change) button
+- "변경" buttons open `dialogs.list_dialog` with the labeled interface list
+- Displays live traffic stats (replaces `StatusMonitor.render_forever`)
+- Shows server connection info (PAC URL, SOCKS/HTTP addresses)
+- Shows last 5 log messages
+- Has a Start/Restart button
+- Keeps `console.set_idle_timer_disabled(True)` active to prevent screen from turning off
+
+### 3. Server lifecycle management (modify `socks5.py`)
+
+- Server start is triggered by UI button, not by script start
+- When interface is changed while running, stop current servers and restart with new settings
+- The asyncio event loop runs in a background thread; UI runs on main thread (Pythonista requirement)
+
+### 4. StatusMonitor adaptation (modify `lib/status.py`)
+
+- Add a method or callback mechanism so the UI can pull/receive stats updates
+- Keep `render_forever` for non-Pythonista (terminal) fallback
+- Add a UI-oriented update path that writes to `ui.Label` references instead of console
+
+## Screen-off Prevention
+
+The existing `console.set_idle_timer_disabled(True)` call is preserved. It will be called during UI initialization to ensure the screen stays on while the proxy is active.
+
+## Flow
+
+1. App starts → detect interfaces → build labeled list
+2. Show UI with auto-selected defaults (existing heuristic: bridge > en for proxy, cell/vpn for connect)
+3. User can change selections via "변경" buttons at any time
+4. User presses Start → servers launch with selected interfaces
+5. Stats update live in UI labels
+6. User changes interface → servers restart automatically with new selection
+
+## Non-Pythonista Fallback
+
+When not running in Pythonista (no `ui` module), fall back to the existing console-based behavior with automatic interface selection. The GUI is Pythonista-only.

--- a/docs/superpowers/specs/2026-03-25-interface-selector-ui-design.md
+++ b/docs/superpowers/specs/2026-03-25-interface-selector-ui-design.md
@@ -54,7 +54,12 @@ Extract the interface enumeration and classification into a reusable function th
 ```python
 def get_labeled_interfaces():
     """Return list of (display_string, iface) tuples for all routable IPv4 interfaces."""
+
+def get_default_selections(labeled_interfaces):
+    """Apply existing heuristic (bridge > en for proxy, cell/vpn for connect) and return default picks."""
 ```
+
+`USE_PHONE_VPN` is superseded by the UI's interface selection and only applies in the non-Pythonista fallback path.
 
 ### 2. UI view (`lib/ui_view.py` — new file)
 
@@ -67,11 +72,37 @@ A Pythonista `ui.View` subclass that:
 - Has a Start/Restart button
 - Keeps `console.set_idle_timer_disabled(True)` active to prevent screen from turning off
 
-### 3. Server lifecycle management (modify `socks5.py`)
+### 3. Server lifecycle management (modify `socks5.py` and `lib/proxy_server.py`)
 
 - Server start is triggered by UI button, not by script start
 - When interface is changed while running, stop current servers and restart with new settings
 - The asyncio event loop runs in a background thread; UI runs on main thread (Pythonista requirement)
+
+**Stop/restart mechanism:**
+- `AsyncProxyServer.run()` must store the `asyncio.Server` handle as `self.server` and expose a `stop()` coroutine that calls `self.server.close()` and `await self.server.wait_closed()`
+- The SOCKS, HTTP, and WPAD server references are stored in a manager object so they can be shut down and recreated
+- WPAD server gets `shutdown()` called before recreation with the new PROXY_HOST
+- In-flight connections are force-closed on restart (acceptable for a proxy; clients will reconnect)
+
+### 4. Concurrency model
+
+**Threading:**
+- Main thread: Pythonista UI event loop
+- Background thread: asyncio event loop (`threading.Thread` running `loop.run_forever()`)
+
+**Cross-thread signaling:**
+- UI → asyncio: use `loop.call_soon_threadsafe()` to schedule stop/start coroutines on the asyncio loop
+- asyncio → UI: stats are read from the main thread via a `ui.View.update()` timer
+
+**Thread safety for stats:**
+- `StatusMonitor` fields are written from asyncio coroutines and read from the UI timer
+- Use `threading.Lock` around `ThroughputTracker.update()` and the counters to prevent torn reads
+- Alternatively, since Pythonista's UI update interval is ~1s, a simple snapshot approach works: the asyncio thread periodically writes a frozen stats dict, and the UI reads it
+
+### 5. Interface refresh
+
+- Re-enumerate interfaces each time the user taps "변경" (Change), so newly connected VPNs or changed networks are visible
+- If the currently selected interface disappears, show a warning in the UI status area
 
 ### 4. StatusMonitor adaptation (modify `lib/status.py`)
 

--- a/lib/interfaces.py
+++ b/lib/interfaces.py
@@ -1,0 +1,65 @@
+import socket
+from lib import ifaddrs
+
+
+def _interface_type_label(name):
+    if name.startswith("bridge"):
+        return "Hotspot"
+    if name.startswith("en"):
+        return "WiFi"
+    if name.startswith("utun"):
+        return "VPN"
+    if name.startswith("pdp_ip"):
+        return "Cellular"
+    return "Other"
+
+
+def get_labeled_interfaces():
+    """Return list of (display_string, iface) for all routable, non-loopback IPv4 interfaces."""
+    non_routable_prefixes = ["ipsec", "awdl", "llw", "nan", "rd"]
+    result = []
+    for iface in ifaddrs.get_interfaces():
+        if not iface.addr:
+            continue
+        if iface.addr.family != socket.AF_INET:
+            continue
+        if iface.name.startswith("lo"):
+            continue
+        if any(iface.name.startswith(p) for p in non_routable_prefixes):
+            continue
+        label = _interface_type_label(iface.name)
+        display = f"{iface.name} - {label} ({iface.addr.address})"
+        result.append((display, iface))
+    return result
+
+
+def get_default_selections(labeled):
+    """Apply heuristic: bridge > en for proxy, cell/vpn for connect. Returns (proxy_idx, connect_idx)."""
+    proxy_idx = None
+    connect_idx = None
+    # Proxy: prefer bridge (hotspot), then en (WiFi)
+    for i, (display, iface) in enumerate(labeled):
+        if iface.name.startswith("bridge"):
+            proxy_idx = i
+            break
+    if proxy_idx is None:
+        for i, (display, iface) in enumerate(labeled):
+            if iface.name.startswith("en"):
+                proxy_idx = i
+                break
+    # Connect: prefer utun (VPN), then pdp_ip (cellular), then any non-proxy interface
+    for i, (display, iface) in enumerate(labeled):
+        if iface.name.startswith("utun"):
+            connect_idx = i
+            break
+    if connect_idx is None:
+        for i, (display, iface) in enumerate(labeled):
+            if iface.name.startswith("pdp_ip"):
+                connect_idx = i
+                break
+    if connect_idx is None:
+        for i, (display, iface) in enumerate(labeled):
+            if not iface.name.startswith("bridge") and not iface.name.startswith("en"):
+                connect_idx = i
+                break
+    return proxy_idx, connect_idx

--- a/lib/proxy_server.py
+++ b/lib/proxy_server.py
@@ -109,6 +109,7 @@ class AsyncProxyServer:
         self.resolver = resolver or Resolver()
         self.connect_host_ipv4 = connect_host_ipv4
         self.connect_host_ipv6 = connect_host_ipv6
+        self._server = None
         self.resolver_source: str | None = None
         if self.connect_host_ipv4 is not None or self.connect_host_ipv6 is not None:
             resolver_afs = [af_for_address(ns) for ns in self.resolver.nameservers]
@@ -145,7 +146,7 @@ class AsyncProxyServer:
         await self._server.serve_forever()
 
     async def stop(self) -> None:
-        if hasattr(self, '_server') and self._server is not None:
+        if self._server is not None:
             self._server.close()
             await self._server.wait_closed()
             self._server = None

--- a/lib/proxy_server.py
+++ b/lib/proxy_server.py
@@ -136,13 +136,19 @@ class AsyncProxyServer:
                 raise Exception("Resolver does not have any suitable nameservers!")
 
     async def run(self) -> None:
-        server = await asyncio.start_server(
+        self._server = await asyncio.start_server(
             self.client_connected,
             host=self.listen_hosts,
             port=self.listen_port,
             reuse_address=True,
         )
-        await server.serve_forever()
+        await self._server.serve_forever()
+
+    async def stop(self) -> None:
+        if hasattr(self, '_server') and self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
 
     async def client_connected(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter

--- a/lib/status.py
+++ b/lib/status.py
@@ -140,30 +140,29 @@ class StatusMonitor(TrafficStats, logging.Handler):
 
             print(self.banner)
 
-            inbound_average, inbound_total = self.inbound.update()
-            outbound_average, outbound_total = self.outbound.update()
+            snap = self.get_snapshot()
             megabit = 1024 * 1024 / 8
             megabyte = 1024 * 1024
 
             # Print the table
             print(f"{'Direction':<12} | {'Traffic (Mbps)':<15}")
             print(f"{'-'*12} | {'-'*15}")
-            print(f"{'In':<12} | {inbound_average / megabit:<15.2f}")
-            print(f"{'Out':<12} | {outbound_average / megabit:<15.2f}")
+            print(f"{'In':<12} | {snap['inbound_speed'] / megabit:<15.2f}")
+            print(f"{'Out':<12} | {snap['outbound_speed'] / megabit:<15.2f}")
             # Print a blank line
             print()
-            print(f"{'Connections:':<12} {self.num_connections:>6}")
-            print(f"{'Total In:':<12} {inbound_total / megabyte:>6.2f} MB")
-            print(f"{'Total Out:':<12} {outbound_total / megabyte:>6.2f} MB")
+            print(f"{'Connections:':<12} {snap['connections']:>6}")
+            print(f"{'Total In:':<12} {snap['inbound_total'] / megabyte:>6.2f} MB")
+            print(f"{'Total Out:':<12} {snap['outbound_total'] / megabyte:>6.2f} MB")
             print(
-                f"{'Total:':<12} {(inbound_total + outbound_total) / megabyte:>6.2f} MB"
+                f"{'Total:':<12} {(snap['inbound_total'] + snap['outbound_total']) / megabyte:>6.2f} MB"
             )
             print()
-            if self.num_errors:
-                print(f"Errors: {self.num_errors}")
-            if self.messages:
+            if snap["errors"]:
+                print(f"Errors: {snap['errors']}")
+            if snap["messages"]:
                 print("Last 5 log messages:")
-                for msg in self.messages:
+                for msg in snap["messages"]:
                     print(f"    {msg}")
 
 

--- a/lib/status.py
+++ b/lib/status.py
@@ -105,11 +105,12 @@ class StatusMonitor(TrafficStats, logging.Handler):
             self.num_connections -= 1
 
     def emit(self, record: logging.LogRecord) -> None:
-        self.messages.append(self.format(record))
-        if len(self.messages) > 5:
-            self.messages = self.messages[-5:]
-        if record.levelno >= logging.ERROR:
-            self.num_errors += 1
+        with self._lock:
+            self.messages.append(self.format(record))
+            if len(self.messages) > 5:
+                self.messages = self.messages[-5:]
+            if record.levelno >= logging.ERROR:
+                self.num_errors += 1
 
     def get_snapshot(self) -> dict:
         """Return a frozen snapshot of current stats for the UI to read.

--- a/lib/status.py
+++ b/lib/status.py
@@ -4,6 +4,7 @@
 import asyncio
 import logging
 import sys
+import threading
 import time
 
 if "Pythonista" in sys.executable:
@@ -85,18 +86,23 @@ class StatusMonitor(TrafficStats, logging.Handler):
         self.num_connections = 0
         self.messages: list[str] = []
         self.num_errors = 0
+        self._lock = threading.Lock()
 
     def add_inbound(self, nbytes: int) -> None:
-        self.inbound.add(nbytes)
+        with self._lock:
+            self.inbound.add(nbytes)
 
     def add_outbound(self, nbytes: int) -> None:
-        self.outbound.add(nbytes)
+        with self._lock:
+            self.outbound.add(nbytes)
 
     def add_connection(self) -> None:
-        self.num_connections += 1
+        with self._lock:
+            self.num_connections += 1
 
     def remove_connection(self) -> None:
-        self.num_connections -= 1
+        with self._lock:
+            self.num_connections -= 1
 
     def emit(self, record: logging.LogRecord) -> None:
         self.messages.append(self.format(record))
@@ -104,6 +110,22 @@ class StatusMonitor(TrafficStats, logging.Handler):
             self.messages = self.messages[-5:]
         if record.levelno >= logging.ERROR:
             self.num_errors += 1
+
+    def get_snapshot(self) -> dict:
+        """Return a frozen snapshot of current stats for the UI to read.
+        Thread-safe: uses a lock to prevent torn reads from ThroughputTracker."""
+        with self._lock:
+            inbound_average, inbound_total = self.inbound.update()
+            outbound_average, outbound_total = self.outbound.update()
+            return {
+                "inbound_speed": inbound_average,
+                "inbound_total": inbound_total,
+                "outbound_speed": outbound_average,
+                "outbound_total": outbound_total,
+                "connections": self.num_connections,
+                "errors": self.num_errors,
+                "messages": list(self.messages),
+            }
 
     async def render_forever(self) -> None:
         while True:

--- a/lib/ui_view.py
+++ b/lib/ui_view.py
@@ -1,5 +1,4 @@
 import sys
-import dialogs
 
 from lib.interfaces import get_labeled_interfaces, get_default_selections
 
@@ -7,6 +6,7 @@ IS_PYTHONISTA = "Pythonista" in sys.executable
 
 if IS_PYTHONISTA:
     import ui
+    import dialogs
     import console
     from objc_util import on_main_thread
 
@@ -210,14 +210,3 @@ class ProxyUIView(ui.View):
         if snap["errors"]:
             self._log_label.text += f"\nErrors: {snap['errors']}"
 
-    @property
-    def proxy_address(self):
-        return self._proxy_iface[1].addr.address if self._proxy_iface else None
-
-    @property
-    def connect_address(self):
-        return self._connect_iface[1].addr.address if self._connect_iface else None
-
-    @property
-    def connect_iface_name(self):
-        return self._connect_iface[1].name if self._connect_iface else None

--- a/lib/ui_view.py
+++ b/lib/ui_view.py
@@ -1,0 +1,223 @@
+import sys
+import dialogs
+
+from lib.interfaces import get_labeled_interfaces, get_default_selections
+
+IS_PYTHONISTA = "Pythonista" in sys.executable
+
+if IS_PYTHONISTA:
+    import ui
+    import console
+    from objc_util import on_main_thread
+
+
+def _make_label(text, frame, font_size=14, alignment=None):
+    lbl = ui.Label()
+    lbl.text = text
+    lbl.frame = frame
+    lbl.font = ("<system>", font_size)
+    if alignment is not None:
+        lbl.alignment = alignment
+    lbl.number_of_lines = 0
+    return lbl
+
+
+def _make_button(title, frame, action):
+    btn = ui.Button(type="system")
+    btn.title = title
+    btn.frame = frame
+    btn.action = action
+    return btn
+
+
+class ProxyUIView(ui.View):
+    def __init__(self, stats, start_server_cb, stop_server_cb, socks_port=9876, http_port=9877, wpad_port=8088):
+        super().__init__()
+        self.name = "SOCKS5 Proxy"
+        self.background_color = "white"
+        self.stats = stats
+        self._start_server_cb = start_server_cb
+        self._stop_server_cb = stop_server_cb
+        self._socks_port = socks_port
+        self._http_port = http_port
+        self._wpad_port = wpad_port
+        self._running = False
+
+        # Current selections
+        self._proxy_iface = None
+        self._connect_iface = None
+
+        # Detect interfaces and pick defaults
+        self._refresh_and_set_defaults()
+
+        # Keep screen on
+        on_main_thread(console.set_idle_timer_disabled)(True)
+
+        self._build_ui()
+        self.update_interval = 1.0
+
+    def _refresh_and_set_defaults(self):
+        labeled = get_labeled_interfaces()
+        proxy_idx, connect_idx = get_default_selections(labeled)
+        if labeled:
+            if proxy_idx is not None:
+                self._proxy_iface = labeled[proxy_idx]
+            else:
+                self._proxy_iface = labeled[0]
+            if connect_idx is not None:
+                self._connect_iface = labeled[connect_idx]
+            elif len(labeled) > 1:
+                self._connect_iface = labeled[1]
+            else:
+                self._connect_iface = labeled[0]
+
+    def _build_ui(self):
+        w = self.width
+        y = 10
+        pad = 10
+
+        # --- Proxy access row ---
+        self._proxy_label = _make_label("", (pad, y, w - 100, 36))
+        self._update_proxy_label()
+        self.add_subview(self._proxy_label)
+
+        self._proxy_btn = _make_button("변경", (w - 80, y, 70, 36), self._change_proxy)
+        self.add_subview(self._proxy_btn)
+        y += 44
+
+        # --- Connect row ---
+        self._connect_label = _make_label("", (pad, y, w - 100, 36))
+        self._update_connect_label()
+        self.add_subview(self._connect_label)
+
+        self._connect_btn = _make_button("변경", (w - 80, y, 70, 36), self._change_connect)
+        self.add_subview(self._connect_btn)
+        y += 52
+
+        # --- Separator ---
+        sep = ui.View(frame=(pad, y, w - 2 * pad, 1))
+        sep.background_color = "#cccccc"
+        self.add_subview(sep)
+        y += 10
+
+        # --- Status label ---
+        self._status_label = _make_label("Status: Stopped", (pad, y, w - 2 * pad, 24), font_size=16)
+        self.add_subview(self._status_label)
+        y += 30
+
+        # --- Stats area ---
+        self._stats_text = ui.TextView()
+        self._stats_text.frame = (pad, y, w - 2 * pad, 200)
+        self._stats_text.editable = False
+        self._stats_text.font = ("<system>", 13)
+        self.add_subview(self._stats_text)
+        y += 210
+
+        # --- Log area ---
+        self._log_label = _make_label("", (pad, y, w - 2 * pad, 100), font_size=11)
+        self.add_subview(self._log_label)
+        y += 110
+
+        # --- Start/Restart button ---
+        self._action_btn = _make_button("Start", (pad, y, w - 2 * pad, 44), self._toggle_server)
+        self._action_btn.background_color = "#007AFF"
+        self._action_btn.tint_color = "white"
+        self._action_btn.corner_radius = 8
+        self.add_subview(self._action_btn)
+
+    def _update_proxy_label(self):
+        display = self._proxy_iface[0] if self._proxy_iface else "None"
+        self._proxy_label.text = f"Proxy: {display}"
+
+    def _update_connect_label(self):
+        display = self._connect_iface[0] if self._connect_iface else "None"
+        self._connect_label.text = f"Connect: {display}"
+
+    def _change_proxy(self, sender):
+        labeled = get_labeled_interfaces()
+        items = [d for d, _ in labeled]
+        choice = dialogs.list_dialog("Proxy 접근 인터페이스", items)
+        if choice is not None:
+            idx = items.index(choice)
+            self._proxy_iface = labeled[idx]
+            self._update_proxy_label()
+            if self._running:
+                self._restart_server()
+
+    def _change_connect(self, sender):
+        labeled = get_labeled_interfaces()
+        items = [d for d, _ in labeled]
+        choice = dialogs.list_dialog("인터넷 연결 인터페이스", items)
+        if choice is not None:
+            idx = items.index(choice)
+            self._connect_iface = labeled[idx]
+            self._update_connect_label()
+            if self._running:
+                self._restart_server()
+
+    def _toggle_server(self, sender):
+        if self._running:
+            self._stop_server_cb()
+            self._running = False
+            self._status_label.text = "Status: Stopped"
+            self._action_btn.title = "Start"
+        else:
+            if self._proxy_iface is None or self._connect_iface is None:
+                dialogs.alert("Error", "Select both interfaces first.")
+                return
+            proxy_addr = self._proxy_iface[1].addr.address
+            connect_addr = self._connect_iface[1].addr.address
+            connect_name = self._connect_iface[1].name
+            self._start_server_cb(proxy_addr, connect_addr, connect_name)
+            self._running = True
+            self._status_label.text = "Status: Running"
+            self._action_btn.title = "Stop"
+
+    def _restart_server(self):
+        self._stop_server_cb()
+        proxy_addr = self._proxy_iface[1].addr.address
+        connect_addr = self._connect_iface[1].addr.address
+        connect_name = self._connect_iface[1].name
+        self._start_server_cb(proxy_addr, connect_addr, connect_name)
+        self._status_label.text = "Status: Running (restarted)"
+
+    def update(self):
+        """Called by Pythonista UI at update_interval frequency."""
+        if not self._running:
+            return
+        snap = self.stats.get_snapshot()
+        megabit = 1024 * 1024 / 8
+        megabyte = 1024 * 1024
+
+        proxy_addr = self._proxy_iface[1].addr.address if self._proxy_iface else "?"
+        lines = [
+            f"In:    {snap['inbound_speed'] / megabit:.2f} Mbps",
+            f"Out:   {snap['outbound_speed'] / megabit:.2f} Mbps",
+            f"",
+            f"Connections: {snap['connections']}",
+            f"Total In:    {snap['inbound_total'] / megabyte:.2f} MB",
+            f"Total Out:   {snap['outbound_total'] / megabyte:.2f} MB",
+            f"Total:       {(snap['inbound_total'] + snap['outbound_total']) / megabyte:.2f} MB",
+            f"",
+            f"PAC URL: http://{proxy_addr}:{self._wpad_port}/wpad.dat",
+            f"SOCKS:   {proxy_addr}:{self._socks_port}",
+            f"HTTP:    {proxy_addr}:{self._http_port}",
+        ]
+        self._stats_text.text = "\n".join(lines)
+
+        if snap["messages"]:
+            self._log_label.text = "Log:\n" + "\n".join(snap["messages"][-5:])
+        if snap["errors"]:
+            self._log_label.text += f"\nErrors: {snap['errors']}"
+
+    @property
+    def proxy_address(self):
+        return self._proxy_iface[1].addr.address if self._proxy_iface else None
+
+    @property
+    def connect_address(self):
+        return self._connect_iface[1].addr.address if self._connect_iface else None
+
+    @property
+    def connect_iface_name(self):
+        return self._connect_iface[1].name if self._connect_iface else None

--- a/lib/ui_view.py
+++ b/lib/ui_view.py
@@ -31,7 +31,15 @@ def _make_button(title, frame, action):
 
 
 class ProxyUIView(ui.View):
-    def __init__(self, stats, start_server_cb, stop_server_cb, socks_port=9876, http_port=9877, wpad_port=8088):
+    def __init__(
+        self,
+        stats,
+        start_server_cb,
+        stop_server_cb,
+        socks_port=9876,
+        http_port=9877,
+        wpad_port=8088,
+    ):
         super().__init__()
         self.name = "SOCKS5 Proxy"
         self.background_color = "white"
@@ -72,58 +80,78 @@ class ProxyUIView(ui.View):
                 self._connect_iface = labeled[0]
 
     def _build_ui(self):
-        w = self.width
-        y = 10
         pad = 10
 
         # --- Proxy access row ---
-        self._proxy_label = _make_label("", (pad, y, w - 100, 36))
+        self._proxy_label = _make_label("", (0, 0, 100, 36))
         self._update_proxy_label()
         self.add_subview(self._proxy_label)
 
-        self._proxy_btn = _make_button("변경", (w - 80, y, 70, 36), self._change_proxy)
+        self._proxy_btn = _make_button("변경", (0, 0, 70, 36), self._change_proxy)
         self.add_subview(self._proxy_btn)
-        y += 44
 
         # --- Connect row ---
-        self._connect_label = _make_label("", (pad, y, w - 100, 36))
+        self._connect_label = _make_label("", (0, 0, 100, 36))
         self._update_connect_label()
         self.add_subview(self._connect_label)
 
-        self._connect_btn = _make_button("변경", (w - 80, y, 70, 36), self._change_connect)
+        self._connect_btn = _make_button("변경", (0, 0, 70, 36), self._change_connect)
         self.add_subview(self._connect_btn)
-        y += 52
 
         # --- Separator ---
-        sep = ui.View(frame=(pad, y, w - 2 * pad, 1))
-        sep.background_color = "#cccccc"
-        self.add_subview(sep)
-        y += 10
+        self._sep = ui.View()
+        self._sep.background_color = "#cccccc"
+        self.add_subview(self._sep)
 
         # --- Status label ---
-        self._status_label = _make_label("Status: Stopped", (pad, y, w - 2 * pad, 24), font_size=16)
+        self._status_label = _make_label(
+            "Status: Stopped", (0, 0, 100, 24), font_size=16
+        )
         self.add_subview(self._status_label)
-        y += 30
 
         # --- Stats area ---
         self._stats_text = ui.TextView()
-        self._stats_text.frame = (pad, y, w - 2 * pad, 200)
         self._stats_text.editable = False
         self._stats_text.font = ("<system>", 13)
         self.add_subview(self._stats_text)
-        y += 210
 
         # --- Log area ---
-        self._log_label = _make_label("", (pad, y, w - 2 * pad, 100), font_size=11)
+        self._log_label = _make_label("", (0, 0, 100, 100), font_size=11)
         self.add_subview(self._log_label)
-        y += 110
 
         # --- Start/Restart button ---
-        self._action_btn = _make_button("Start", (pad, y, w - 2 * pad, 44), self._toggle_server)
+        self._action_btn = _make_button("Start", (0, 0, 100, 44), self._toggle_server)
         self._action_btn.background_color = "#007AFF"
         self._action_btn.tint_color = "white"
         self._action_btn.corner_radius = 8
         self.add_subview(self._action_btn)
+
+    def layout(self):
+        w = self.width
+        pad = 10
+        y = 10
+
+        self._proxy_label.frame = (pad, y, w - 100, 36)
+        self._proxy_btn.frame = (w - 80, y, 70, 36)
+        y += 44
+
+        self._connect_label.frame = (pad, y, w - 100, 36)
+        self._connect_btn.frame = (w - 80, y, 70, 36)
+        y += 52
+
+        self._sep.frame = (pad, y, w - 2 * pad, 1)
+        y += 10
+
+        self._status_label.frame = (pad, y, w - 2 * pad, 24)
+        y += 30
+
+        self._stats_text.frame = (pad, y, w - 2 * pad, 200)
+        y += 210
+
+        self._log_label.frame = (pad, y, w - 2 * pad, 100)
+        y += 110
+
+        self._action_btn.frame = (pad, y, w - 2 * pad, 44)
 
     def _update_proxy_label(self):
         display = self._proxy_iface[0] if self._proxy_iface else "None"
@@ -209,4 +237,3 @@ class ProxyUIView(ui.View):
             self._log_label.text = "Log:\n" + "\n".join(snap["messages"][-5:])
         if snap["errors"]:
             self._log_label.text += f"\nErrors: {snap['errors']}"
-

--- a/socks5.py
+++ b/socks5.py
@@ -57,6 +57,19 @@ def is_globally_routable(ipv6_address):
     return True
 
 
+def is_routable_interface(interface_name):
+    non_routable_interface_prefixes = [
+        "ipsec",
+        "awdl",
+        "llw",
+        "nan",
+        "rd",
+    ]
+    return not any(
+        interface_name.startswith(prefix) for prefix in non_routable_interface_prefixes
+    )
+
+
 DEFAULT_RESOLVERS = [
     "1.0.0.1",
     "1.1.1.1",
@@ -154,7 +167,7 @@ try:
                 iface
                 for iface in iftypes["cell"]
                 if iface.addr.family == socket.AF_INET
-                and not iface.addr.address.startswith("192.0.0.")
+                and is_routable_interface(iface.name)
             ),
             None,
         )
@@ -178,6 +191,7 @@ try:
                 and iface.addr.address
                 and (is_globally_routable(iface.addr.address) if not is_vpn else True)
                 and iface.name == iface_ipv4.name
+                and is_routable_interface(iface.name)
             ]
 
             # Select the last IPv6 address to select the temporary address for reduced tracking
@@ -191,6 +205,7 @@ try:
                 if iface.addr.family == socket.AF_INET6
                 and iface.addr.address
                 and is_globally_routable(iface.addr.address)
+                and is_routable_interface(iface.name)
             ]
 
             # Select the last IPv6 address to select the temporary address for reduced tracking

--- a/socks5.py
+++ b/socks5.py
@@ -150,7 +150,12 @@ try:
 
     if iftypes["cell"]:
         iface_ipv4 = next(
-            (iface for iface in iftypes["cell"] if iface.addr.family == socket.AF_INET),
+            (
+                iface
+                for iface in iftypes["cell"]
+                if iface.addr.family == socket.AF_INET
+                and not iface.addr.address.startswith("192.0.0.")
+            ),
             None,
         )
         iface_ipv6 = None

--- a/socks5.py
+++ b/socks5.py
@@ -232,7 +232,8 @@ class ServerManager:
                 self._socks_task, self._http_task, return_exceptions=True
             )
 
-        self._loop.create_task(_serve())
+        # Schedule _serve() to run once the loop starts, then run the loop
+        self._loop.call_soon(lambda: asyncio.ensure_future(_serve(), loop=self._loop))
         self._loop.run_forever()
 
     def _run_wpad(self):

--- a/socks5.py
+++ b/socks5.py
@@ -2,9 +2,11 @@
 # Socks5/HTTP Proxy server for Pythonista by @nneonneo
 # Pretty statistics view and IPv6 support added by @philrosenthal
 
+import asyncio
 import ipaddress
 import logging
 import socket
+import sys
 import threading
 
 from lib.socks5_server import AsyncSocks5Handler
@@ -14,14 +16,6 @@ from lib.status import StatusMonitor
 
 logging.basicConfig(level=logging.ERROR)
 
-# IP over which the proxy will be available (probably WiFi IP)
-PROXY_HOST = "172.20.10.1"
-# IP over which the proxy will attempt to connect to the Internet
-CONNECT_HOST_IPV4 = "0.0.0.0"
-CONNECT_HOST_IPV6 = None
-# Time out connections after being idle for this long (in seconds)
-IDLE_TIMEOUT = 1800
-
 LISTEN_HOST = "0.0.0.0"
 SOCKS_PORT = 9876
 HTTP_PORT = 9877
@@ -30,26 +24,19 @@ WPAD_PORT = 8088
 USE_PHONE_VPN = True
 CUSTOM_RESOLVERS = []
 
-# Try to keep the screen from turning off (iOS)
-try:
-    import console
-    from objc_util import on_main_thread
-
-    on_main_thread(console.set_idle_timer_disabled)(True)
-except ImportError:
-    pass
+IS_PYTHONISTA = "Pythonista" in sys.executable
 
 
 def is_globally_routable(ipv6_address):
     non_routable_networks = [
-        "ff00::/8",  # Multicast address range
-        "fe80::/10",  # Link-local address range
-        "fc00::/7",  # Unique local address range
-        "::/8",  # Unspecified address range
-        "2001:db8::/32",  # Documentation address range
-        "2001::/32",  # Teredo address range
-        "2002::/16",  # 6to4 address range
-        "ff02::/16",  # Link-local multicast address range
+        "ff00::/8",
+        "fe80::/10",
+        "fc00::/7",
+        "::/8",
+        "2001:db8::/32",
+        "2001::/32",
+        "2002::/16",
+        "ff02::/16",
     ]
     for network in non_routable_networks:
         if ipaddress.ip_address(ipv6_address) in ipaddress.ip_network(network):
@@ -80,169 +67,65 @@ DEFAULT_RESOLVERS = [
 ]
 
 try:
-    # TODO: configurable DNS (or find a way to use the cell network's own DNS)
     import dns.asyncresolver
 
     resolver = dns.asyncresolver.Resolver(configure=False)
     resolver.nameservers += CUSTOM_RESOLVERS or DEFAULT_RESOLVERS
 except ImportError:
-    # pip install dnspython
     print("Warning: dnspython not available; falling back to system DNS")
     resolver = None
 
-try:
-    # We want the WiFi address so that clients know what IP to use.
-    # We want the non-WiFi (cellular?) address so that we can force network
-    #  traffic to go over that network. This allows the proxy to correctly
-    #  forward traffic to the cell network even when the WiFi network is
-    #  internet-enabled but limited (e.g. firewalled)
 
-    from collections import defaultdict
-
+def resolve_ipv6_for_interface(iface_name, is_vpn=False):
+    """Find the best IPv6 address matching a given interface name."""
     from lib import ifaddrs
 
-    initial_output = ""
-    ipv4_output = ""
-    ipv6_output = ""
+    all_ifaces = ifaddrs.get_interfaces()
+    # First try: match by interface name
+    ipv6_list = [
+        iface
+        for iface in all_ifaces
+        if iface.addr
+        and iface.addr.family == socket.AF_INET6
+        and iface.addr.address
+        and iface.name == iface_name
+        and is_routable_interface(iface.name)
+        and (is_globally_routable(iface.addr.address) if not is_vpn else True)
+    ]
+    if ipv6_list:
+        return ipv6_list[-1].addr.address
 
-    interfaces = ifaddrs.get_interfaces()
-    iftypes = defaultdict(list)
+    # Fallback: any routable IPv6
+    if not is_vpn:
+        ipv6_list = [
+            iface
+            for iface in all_ifaces
+            if iface.addr
+            and iface.addr.family == socket.AF_INET6
+            and iface.addr.address
+            and is_globally_routable(iface.addr.address)
+            and is_routable_interface(iface.name)
+        ]
+        if ipv6_list:
+            return ipv6_list[-1].addr.address
+    return None
 
-    for iface in interfaces:
-        if not iface.addr:
-            continue
-        if iface.name.startswith("lo"):
-            continue
-        # XXX implement better classification of interfaces
-        if iface.name.startswith("en"):
-            iftypes["en"].append(iface)
-        elif iface.name.startswith("bridge"):
-            iftypes["bridge"].append(iface)
-        elif iface.name.startswith("utun"):
-            iftypes["vpn"].append(iface)
-        else:
-            iftypes["cell"].append(iface)
 
-    if iftypes["vpn"] and USE_PHONE_VPN:
-        ipv4_output += "VPN use enabled (change with USE_PHONE_VPN)\n"
-        new_ifaces = []
-        new_ifaces.extend(iftypes["vpn"])
-        new_ifaces.extend(iftypes["cell"])
-        iftypes["cell"] = new_ifaces
-
-    if iftypes["bridge"]:
-        iface = next(
-            (
-                iface
-                for iface in iftypes["bridge"]
-                if iface.addr.family == socket.AF_INET
-            ),
-            None,
-        )
-        if iface:
-            initial_output = (
-                "Assuming proxy will be accessed over hotspot (%s) at %s\n"
-                % (iface.name, iface.addr.address)
-            )
-            PROXY_HOST = iface.addr.address
-    elif iftypes["en"]:
-        iface = next(
-            (iface for iface in iftypes["en"] if iface.addr.family == socket.AF_INET),
-            None,
-        )
-        if iface:
-            initial_output += (
-                "Assuming proxy will be accessed over WiFi (%s) at %s\n"
-                % (iface.name, iface.addr.address)
-            )
-            PROXY_HOST = iface.addr.address
-    else:
-        initial_output += (
-            "Warning: could not get WiFi address; assuming %s\n" % PROXY_HOST
-        )
-
-    if iftypes["cell"]:
-        iface_ipv4 = next(
-            (
-                iface
-                for iface in iftypes["cell"]
-                if iface.addr.family == socket.AF_INET
-                and is_routable_interface(iface.name)
-            ),
-            None,
-        )
-        iface_ipv6 = None
-
-        is_vpn = iface_ipv4 and iface_ipv4.name.startswith("utun")
-
-        if iface_ipv4:
-            iface_ipv4.addr.address
-            ipv4_output += "Will connect to IPv4 servers over interface %s at %s\n" % (
-                iface_ipv4.name,
-                iface_ipv4.addr.address,
-            )
-            CONNECT_HOST_IPV4 = iface_ipv4.addr.address
-
-            # Create a list of all IPv6 addresse that are globally routable and match the IPv4 interface
-            iface_ipv6_list = [
-                iface
-                for iface in iftypes["cell"]
-                if iface.addr.family == socket.AF_INET6
-                and iface.addr.address
-                and (is_globally_routable(iface.addr.address) if not is_vpn else True)
-                and iface.name == iface_ipv4.name
-                and is_routable_interface(iface.name)
-            ]
-
-            # Select the last IPv6 address to select the temporary address for reduced tracking
-            iface_ipv6 = iface_ipv6_list[-1] if iface_ipv6_list else None
-
-        if iface_ipv6 is None and not is_vpn:
-            # Create a list of all IPv6 addresses that are globally routable
-            iface_ipv6_list = [
-                iface
-                for iface in iftypes["cell"]
-                if iface.addr.family == socket.AF_INET6
-                and iface.addr.address
-                and is_globally_routable(iface.addr.address)
-                and is_routable_interface(iface.name)
-            ]
-
-            # Select the last IPv6 address to select the temporary address for reduced tracking
-            iface_ipv6 = iface_ipv6_list[-1] if iface_ipv6_list else None
-
-        if iface_ipv6:
-            iface_ipv6.addr.address
-            ipv6_output += "Will connect to IPv6 servers over interface %s at %s\n" % (
-                iface_ipv6.name,
-                iface_ipv6.addr.address,
-            )
-            # Test IPv6 connectivity
-            try:
-                test_socket = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-                test_socket.settimeout(5)
-                test_socket.bind((iface_ipv6.addr.address, 0))
-                test_socket.connect(("2606:4700:4700::1111", 80))
-                test_socket.close()
-                CONNECT_HOST_IPV6 = iface_ipv6.addr.address
-            except Exception as e:
-                ipv6_output += (
-                    "Failed to connect to 2606:4700:4700::1111 over IPv6 due to: %s\n"
-                    % str(e)
-                )
-                CONNECT_HOST_IPV6 = None
-            finally:
-                test_socket.close()
-
-    initial_output += ipv4_output + ipv6_output
-    print(initial_output)
-except Exception as e:
-    logging.error("Address detection failed: %s: %s", (type(e).__name__, e))
-    import traceback
-
-    traceback.print_exc()
-
-    interfaces = None
+def test_ipv6_connectivity(ipv6_address):
+    """Test if an IPv6 address can reach the internet. Returns the address or None."""
+    try:
+        test_socket = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        test_socket.settimeout(5)
+        test_socket.bind((ipv6_address, 0))
+        test_socket.connect(("2606:4700:4700::1111", 80))
+        test_socket.close()
+        return ipv6_address
+    except Exception:
+        try:
+            test_socket.close()
+        except Exception:
+            pass
+        return None
 
 
 def create_wpad_server(hhost, hport, phost, pport):
@@ -285,15 +168,234 @@ function FindProxyForURL(url, host)
     return server
 
 
-def run_wpad_server(server):
+# --- Server lifecycle management ---
+
+
+class ServerManager:
+    """Manages SOCKS, HTTP, and WPAD server lifecycle."""
+
+    def __init__(self, stats):
+        self.stats = stats
+        self._loop = None
+        self._thread = None
+        self._socks_server = None
+        self._http_server = None
+        self._wpad_server = None
+        self._wpad_thread = None
+        self._socks_task = None
+        self._http_task = None
+
+    def start(self, proxy_host, connect_host_ipv4, connect_iface_name):
+        is_vpn = connect_iface_name.startswith("utun")
+        ipv6_addr = resolve_ipv6_for_interface(connect_iface_name, is_vpn=is_vpn)
+        connect_host_ipv6 = test_ipv6_connectivity(ipv6_addr) if ipv6_addr else None
+
+        # WPAD server
+        self._wpad_server = create_wpad_server(
+            LISTEN_HOST, WPAD_PORT, proxy_host, SOCKS_PORT
+        )
+        self._wpad_thread = threading.Thread(target=self._run_wpad, daemon=True)
+        self._wpad_thread.start()
+
+        # asyncio event loop in background thread
+        self._loop = asyncio.new_event_loop()
+
+        self._socks_server = AsyncProxyServer(
+            AsyncSocks5Handler,
+            listen_hosts=LISTEN_HOST,
+            listen_port=SOCKS_PORT,
+            traffic_stats=self.stats,
+            resolver=resolver,
+            connect_host_ipv4=connect_host_ipv4,
+            connect_host_ipv6=connect_host_ipv6,
+        )
+        self._http_server = AsyncProxyServer(
+            AsyncHTTPProxyHandler,
+            listen_hosts=LISTEN_HOST,
+            listen_port=HTTP_PORT,
+            traffic_stats=self.stats,
+            resolver=resolver,
+            connect_host_ipv4=connect_host_ipv4,
+            connect_host_ipv6=connect_host_ipv6,
+        )
+
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+
+    def _run_loop(self):
+        asyncio.set_event_loop(self._loop)
+
+        async def _serve():
+            self._socks_task = asyncio.create_task(self._socks_server.run())
+            self._http_task = asyncio.create_task(self._http_server.run())
+            await asyncio.gather(
+                self._socks_task, self._http_task, return_exceptions=True
+            )
+
+        self._loop.create_task(_serve())
+        self._loop.run_forever()
+
+    def _run_wpad(self):
+        try:
+            self._wpad_server.serve_forever()
+        except Exception:
+            pass
+
+    def stop(self):
+        if self._loop and self._loop.is_running():
+
+            async def _stop_all():
+                if self._socks_server:
+                    await self._socks_server.stop()
+                if self._http_server:
+                    await self._http_server.stop()
+                for task in [self._socks_task, self._http_task]:
+                    if task and not task.done():
+                        task.cancel()
+
+            future = asyncio.run_coroutine_threadsafe(_stop_all(), self._loop)
+            future.result(timeout=5)
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._thread.join(timeout=5)
+
+        if self._wpad_server:
+            self._wpad_server.shutdown()
+            self._wpad_server = None
+
+        self._socks_server = None
+        self._http_server = None
+        self._loop = None
+        self._thread = None
+
+
+# --- Entry points ---
+
+
+def run_with_ui():
+    """Pythonista GUI mode."""
+    from lib.ui_view import ProxyUIView
+
+    stats = StatusMonitor("")
+    logging.getLogger().addHandler(stats)
+    manager = ServerManager(stats)
+
+    def start_server(proxy_addr, connect_addr, connect_name):
+        manager.start(proxy_addr, connect_addr, connect_name)
+
+    def stop_server():
+        manager.stop()
+
+    view = ProxyUIView(
+        stats,
+        start_server,
+        stop_server,
+        socks_port=SOCKS_PORT,
+        http_port=HTTP_PORT,
+        wpad_port=WPAD_PORT,
+    )
+    view.present("fullscreen")
+
+
+def run_console():
+    """Original console mode for non-Pythonista environments."""
+    from collections import defaultdict
+
+    from lib import ifaddrs
+
+    # Keep screen on in Pythonista console mode
     try:
-        server.serve_forever()
-    except KeyboardInterrupt:
+        import console
+        from objc_util import on_main_thread
+
+        on_main_thread(console.set_idle_timer_disabled)(True)
+    except ImportError:
         pass
 
+    PROXY_HOST = "172.20.10.1"
+    CONNECT_HOST_IPV4 = "0.0.0.0"
+    CONNECT_HOST_IPV6 = None
+    initial_output = ""
 
-if __name__ == "__main__":
-    import asyncio
+    try:
+        interfaces = ifaddrs.get_interfaces()
+        iftypes = defaultdict(list)
+
+        for iface in interfaces:
+            if not iface.addr:
+                continue
+            if iface.name.startswith("lo"):
+                continue
+            if iface.name.startswith("en"):
+                iftypes["en"].append(iface)
+            elif iface.name.startswith("bridge"):
+                iftypes["bridge"].append(iface)
+            elif iface.name.startswith("utun"):
+                iftypes["vpn"].append(iface)
+            else:
+                iftypes["cell"].append(iface)
+
+        if iftypes["vpn"] and USE_PHONE_VPN:
+            initial_output += "VPN use enabled (change with USE_PHONE_VPN)\n"
+            new_ifaces = list(iftypes["vpn"]) + list(iftypes["cell"])
+            iftypes["cell"] = new_ifaces
+
+        if iftypes["bridge"]:
+            iface = next(
+                (i for i in iftypes["bridge"] if i.addr.family == socket.AF_INET),
+                None,
+            )
+            if iface:
+                initial_output += (
+                    "Assuming proxy will be accessed over hotspot (%s) at %s\n"
+                    % (iface.name, iface.addr.address)
+                )
+                PROXY_HOST = iface.addr.address
+        elif iftypes["en"]:
+            iface = next(
+                (i for i in iftypes["en"] if i.addr.family == socket.AF_INET), None
+            )
+            if iface:
+                initial_output += (
+                    "Assuming proxy will be accessed over WiFi (%s) at %s\n"
+                    % (iface.name, iface.addr.address)
+                )
+                PROXY_HOST = iface.addr.address
+        else:
+            initial_output += (
+                "Warning: could not get WiFi address; assuming %s\n" % PROXY_HOST
+            )
+
+        if iftypes["cell"]:
+            iface_ipv4 = next(
+                (
+                    i
+                    for i in iftypes["cell"]
+                    if i.addr.family == socket.AF_INET
+                    and is_routable_interface(i.name)
+                ),
+                None,
+            )
+            if iface_ipv4:
+                initial_output += (
+                    "Will connect to IPv4 servers over interface %s at %s\n"
+                    % (iface_ipv4.name, iface_ipv4.addr.address)
+                )
+                CONNECT_HOST_IPV4 = iface_ipv4.addr.address
+                is_vpn = iface_ipv4.name.startswith("utun")
+                ipv6_addr = resolve_ipv6_for_interface(
+                    iface_ipv4.name, is_vpn=is_vpn
+                )
+                if ipv6_addr:
+                    CONNECT_HOST_IPV6 = test_ipv6_connectivity(ipv6_addr)
+                    if CONNECT_HOST_IPV6:
+                        initial_output += (
+                            "Will connect to IPv6 servers at %s\n" % CONNECT_HOST_IPV6
+                        )
+    except Exception as e:
+        logging.error("Address detection failed: %s: %s", type(e).__name__, e)
+        import traceback
+
+        traceback.print_exc()
 
     wpad_server = create_wpad_server(LISTEN_HOST, WPAD_PORT, PROXY_HOST, SOCKS_PORT)
 
@@ -307,12 +409,13 @@ if __name__ == "__main__":
     stats = StatusMonitor(initial_output)
     logging.getLogger().addHandler(stats)
 
-    thread = threading.Thread(target=run_wpad_server, args=(wpad_server,))
-    thread.daemon = True
+    thread = threading.Thread(
+        target=lambda: wpad_server.serve_forever(), daemon=True
+    )
     thread.start()
 
     async def main():
-        server = AsyncProxyServer(
+        socks = AsyncProxyServer(
             AsyncSocks5Handler,
             listen_hosts=LISTEN_HOST,
             listen_port=SOCKS_PORT,
@@ -321,9 +424,9 @@ if __name__ == "__main__":
             connect_host_ipv4=CONNECT_HOST_IPV4,
             connect_host_ipv6=CONNECT_HOST_IPV6,
         )
-        asyncio.create_task(server.run())
+        asyncio.create_task(socks.run())
 
-        server = AsyncProxyServer(
+        http = AsyncProxyServer(
             AsyncHTTPProxyHandler,
             listen_hosts=LISTEN_HOST,
             listen_port=HTTP_PORT,
@@ -332,7 +435,7 @@ if __name__ == "__main__":
             connect_host_ipv4=CONNECT_HOST_IPV4,
             connect_host_ipv6=CONNECT_HOST_IPV6,
         )
-        asyncio.create_task(server.run())
+        asyncio.create_task(http.run())
 
         await stats.render_forever()
 
@@ -341,3 +444,10 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         print("Shutting down.")
         wpad_server.shutdown()
+
+
+if __name__ == "__main__":
+    if IS_PYTHONISTA:
+        run_with_ui()
+    else:
+        run_console()

--- a/socks5.py
+++ b/socks5.py
@@ -233,7 +233,7 @@ class ServerManager:
             )
 
         # Schedule _serve() to run once the loop starts, then run the loop
-        self._loop.call_soon(lambda: asyncio.ensure_future(_serve(), loop=self._loop))
+        self._loop.call_soon(lambda: asyncio.ensure_future(_serve()))
         self._loop.run_forever()
 
     def _run_wpad(self):
@@ -255,7 +255,10 @@ class ServerManager:
                         task.cancel()
 
             future = asyncio.run_coroutine_threadsafe(_stop_all(), self._loop)
-            future.result(timeout=5)
+            try:
+                future.result(timeout=5)
+            except Exception:
+                logging.warning("Server stop timed out; forcing shutdown")
             self._loop.call_soon_threadsafe(self._loop.stop)
             self._thread.join(timeout=5)
 


### PR DESCRIPTION
The current implementation of iOS-SOCKS-Server uses the first AF_INET network interface as the SOCKS5 proxy's connect host.

While investigating a connectivity issue where the server was incorrectly mapping to ipsec interfaces (which are non routable for external proxy clients), further research revealed that this logic is also susceptible to binding with other Apple specific internal interfaces.

Specifically, interfaces such as awdl0 (AirDrop), nan0 (Neighbor Awareness Networking), and llw0 are frequently active on iOS. Since these are designed for peer-to-peer or low-latency local tasks and lack a default gateway, binding the SOCKS5 server to them makes the proxy unreachable from external clients.